### PR TITLE
 Temporary fix for SSL certificate error

### DIFF
--- a/default.py
+++ b/default.py
@@ -31,7 +31,8 @@ except:
 	# pre-frodo and python 2.4
 	import simplejson as json
 	from cgi import parse_qs
-
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
 # Plugin constants
 __settings__ = xbmcaddon.Addon(id='plugin.video.furk')
 __plugin__ = 'Furk.net'


### PR DESCRIPTION
This is a dirty fix to sidestep the certificate error being caused as hostname 'api.furk.net' doesn't match either of 'www.furk.net', 'furk.net' .
The error log is shown below.

```
-->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <class 'ssl.CertificateError'>
                                            Error Contents: hostname 'api.furk.net' doesn't match either of 'www.furk.net', 'furk.net'
                                            Traceback (most recent call last):
                                              File "/home/abhi/.kodi/addons/Furk-XBMC-Video-Plugin-master/default.py", line 260, in <module>
                                                runner()
                                              File "/home/abhi/.kodi/addons/Furk-XBMC-Video-Plugin-master/default.py", line 148, in runner
                                                api_key = api.login(login=__settings__.getSetting('login'), pwd=__settings__.getSetting('password'))
                                              File "/home/abhi/.kodi/addons/Furk-XBMC-Video-Plugin-master/default.py", line 74, in login
                                                resp = self._call('login/login', {"login": login, "pwd": pwd})
                                              File "/home/abhi/.kodi/addons/Furk-XBMC-Video-Plugin-master/default.py", line 80, in _call
                                                body = self._fetch(url, params)
                                              File "/home/abhi/.kodi/addons/Furk-XBMC-Video-Plugin-master/default.py", line 95, in _fetch
                                                response = opener.open(req)
                                              File "/usr/lib/python2.7/urllib2.py", line 431, in open
                                                response = self._open(req, data)
                                              File "/usr/lib/python2.7/urllib2.py", line 449, in _open
                                                '_open', req)
                                              File "/usr/lib/python2.7/urllib2.py", line 409, in _call_chain
                                                result = func(*args)
                                              File "/usr/lib/python2.7/urllib2.py", line 1240, in https_open
                                                context=self._context)
                                              File "/usr/lib/python2.7/urllib2.py", line 1194, in do_open
                                                h.request(req.get_method(), req.get_selector(), req.data, headers)
                                              File "/usr/lib/python2.7/httplib.py", line 1053, in request
                                                self._send_request(method, url, body, headers)
                                              File "/usr/lib/python2.7/httplib.py", line 1093, in _send_request
                                                self.endheaders(body)
                                              File "/usr/lib/python2.7/httplib.py", line 1049, in endheaders
                                                self._send_output(message_body)
                                              File "/usr/lib/python2.7/httplib.py", line 893, in _send_output
                                                self.send(msg)
                                              File "/usr/lib/python2.7/httplib.py", line 855, in send
                                                self.connect()
                                              File "/usr/lib/python2.7/httplib.py", line 1274, in connect
                                                server_hostname=server_hostname)
                                              File "/usr/lib/python2.7/ssl.py", line 352, in wrap_socket
                                                _context=self)
                                              File "/usr/lib/python2.7/ssl.py", line 579, in __init__
                                                self.do_handshake()
                                              File "/usr/lib/python2.7/ssl.py", line 816, in do_handshake
                                                match_hostname(self.getpeercert(), self.server_hostname)
                                              File "/usr/lib/python2.7/ssl.py", line 271, in match_hostname
                                                % (hostname, ', '.join(map(repr, dnsnames))))
                                            CertificateError: hostname 'api.furk.net' doesn't match either of 'www.furk.net', 'furk.net'
                                            -->End of Python script error report<--
```
